### PR TITLE
Link update

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -183,12 +183,21 @@
       {
         "dropdown": "Tutorials",
         "icon": {
-                  "name": "person-to-portal",
-                  "style": "regular"
-                },
+          "name": "person-to-portal",
+          "style": "regular"
+        },
         "pages": [
           "docs/tutorials/index-quick-start",
-          "/docs/getting-started/start",
+          {
+            "group": "Getting Started",
+            "icon": {
+              "name": "play",
+              "style": "regular"
+            },
+            "pages": [
+              "/docs/getting-started/start"
+            ]
+          },
           {
             "group": "Super Quick Start Tutorials",
             "icon": {
@@ -200,7 +209,6 @@
               "docs/tutorials/python-example",
               "docs/tutorials/javascript-example",
               "docs/tutorials/rust-example"
-              
             ]
           }
         ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -81,7 +81,7 @@ dstack supports multiple ways to deploy your apps—use a partner-managed cloud 
   <Card 
     title="Deploy Your Own dstack Framework" 
     icon="server" 
-    href="/docs/getting-started/installation"
+    href="/docs/getting-started/start"
     className="hover:shadow-lg transition-shadow border-2 border-purple-200"
   >
     <div className="space-y-3">
@@ -122,7 +122,7 @@ dstack supports multiple ways to deploy your apps—use a partner-managed cloud 
   <Card 
     title="Tutorials" 
     icon="graduation-cap" 
-    href="/docs/tutorials/index"
+    href="/docs/tutorials/index-quick-start"
     className="hover:shadow-lg transition-shadow border-2 border-gray-200 rounded-lg p-4"
   >
     <p className="mb-4">Step-by-step guides for common use cases</p>


### PR DESCRIPTION
This pull request updates the documentation structure and navigation links to improve user experience and consistency. The most important changes include grouping "Getting Started" pages in `docs.json` with additional metadata, removing unnecessary whitespace, and updating navigation links in `docs/index.mdx` to align with the new structure.

### Documentation structure updates:
* [`docs.json`](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eL191-R200): Grouped "Getting Started" pages under a new "Getting Started" section with an associated icon and metadata for better organization.
* [`docs.json`](diffhunk://#diff-b7b4169fa5b2e02aa17d40553a73c5d9520086753c501eeb926c63b162bb6d9eL203): Removed unnecessary trailing whitespace in the list of tutorial pages.

### Navigation link updates:
* [`docs/index.mdx`](diffhunk://#diff-135108c7d936a6d1e05ce4ecaa854c5dccdea8ad5d317e08d61639b9ffbc6425L84-R84): Updated the "Deploy Your Own dstack Framework" card link to point to `/docs/getting-started/start` instead of `/docs/getting-started/installation`.
* [`docs/index.mdx`](diffhunk://#diff-135108c7d936a6d1e05ce4ecaa854c5dccdea8ad5d317e08d61639b9ffbc6425L125-R125): Updated the "Tutorials" card link to point to `/docs/tutorials/index-quick-start` instead of `/docs/tutorials/index`.